### PR TITLE
解决接口参数如果设置正规表达式，不是必须参数情况下，依然要验证REGX的问题

### DIFF
--- a/vendor/phalapi/kernal/src/Request/Formatter/StringFormatter.php
+++ b/vendor/phalapi/kernal/src/Request/Formatter/StringFormatter.php
@@ -45,7 +45,7 @@ class StringFormatter extends BaseFormatter implements Formatter {
      * 进行正则匹配
      */
     protected function filterByRegex($value, $rule) {
-        if (!isset($rule['regex']) || empty($rule['regex'])) {
+        if (!isset($rule['regex']) || empty($rule['regex']) || empty($value)) {
             return;
         }
 


### PR DESCRIPTION
### 接口参数配置
![](http://chuantu.biz/t6/327/1528793746x-1376440192.png)
### 1.表单数据
![](http://chuantu.biz/t6/327/1528793627x-1376440192.png)
### 返回数据
![](http://chuantu.biz/t6/327/1528793715x-1376440192.png)