### PR TITLE
重写数据库路由，优化其对多数据库的支持以及自定义方式

### DIFF
--- a/config/dbs.php
+++ b/config/dbs.php
@@ -7,44 +7,78 @@
  * @author: dogstar <chanzonghuang@gmail.com> 2015-02-09
  */
 
+ 
+ /**
+  * 重写db路由，使其支持动态写入多数据库
+  * 假设现在除了默认数据库外还有数据库 ab_1
+  */
+ $TABLES  = array(
+    '__default__' => array(                     //先写入默认路由
+        'prefix' => '',
+        'key' => 'id',
+        'map' => array(
+            array('db' => 'db_master')
+        ),
+    )
+ );
+ //所有的数据库
+ $SERVERS = array(
+    'db_master' => array(                       //服务器标记
+        'type'      => 'mysql',                 //数据库类型，暂时只支持：mysql, sqlserver
+        'host'      => '127.0.0.1',             //数据库域名
+        'name'      => 'phalapi',               //数据库名字
+        'user'      => 'root',                  //数据库用户名
+        'password'  => '',	                    //数据库密码
+        'port'      => 3306,                    //数据库端口
+        'charset'   => 'UTF8',                  //数据库字符集
+    ),
+    'db_1' => array(                         //另外一个数据库
+        'type'      => 'mysql',
+        'host'      => '127.0.0.1',
+        'name'      => 'phalapi',
+        'user'      => 'root',
+        'password'  => '',
+        'port'      => 3306,
+        'charset'   => 'UTF8',
+    ),
+ );
+
+ //自定义的数据库
+$customServerDatabases = array(                 //除默认数据库外的数据库的表
+    'db_1' => array(                            //数据库db_1的表，需要将ab_1的表名写到这里
+        'table1',
+        'table2',
+        'table3',
+    ),
+    // 'db_2' => array(   //其他数据库的表
+    //     'table1',
+    //     'table2',
+    // )
+);
+
+//将server下自定义的表写入到路由中
+foreach ($customServerDatabases as $serverName => $tables) {
+    foreach ($tables as $tableName) {
+        $aTable = array(
+            'prefix' => '',
+            'key' => 'id',
+            'map' => array(
+                array('db' => $serverName)
+            ),
+        );
+        $TABLES[$tableName] = $aTable;
+    }
+}
+
+
 return array(
     /**
      * DB数据库服务器集群
      */
-    'servers' => array(
-        'db_master' => array(                       //服务器标记
-            'type'      => 'mysql',                 //数据库类型，暂时只支持：mysql, sqlserver
-            'host'      => '127.0.0.1',             //数据库域名
-            'name'      => 'phalapi',               //数据库名字
-            'user'      => 'root',                  //数据库用户名
-            'password'  => '',	                    //数据库密码
-            'port'      => 3306,                    //数据库端口
-            'charset'   => 'UTF8',                  //数据库字符集
-        ),
-    ),
+    'servers' => $SERVERS,
 
     /**
-     * 自定义路由表
+     * 自定义的路由表
      */
-    'tables' => array(
-        //通用路由
-        '__default__' => array(
-            'prefix' => 'tbl_',
-            'key' => 'id',
-            'map' => array(
-                array('db' => 'db_master'),
-            ),
-        ),
-
-        /**
-        'demo' => array(                                                //表名
-            'prefix' => 'tbl_',                                         //表名前缀
-            'key' => 'id',                                              //表主键名
-            'map' => array(                                             //表路由配置
-                array('db' => 'db_master'),                               //单表配置：array('db' => 服务器标记)
-                array('start' => 0, 'end' => 2, 'db' => 'db_master'),     //分表配置：array('start' => 开始下标, 'end' => 结束下标, 'db' => 服务器标记)
-            ),
-        ),
-         */
-    ),
+    'tables' => $TABLES
 );


### PR DESCRIPTION
原来多数据库每多一个数据库，就要多写一项
`
'prefix' => '',
'key' => 'id',
'map' => array(
    array('db' => ‘db_name’)
),
`
现在优化为，设置一个array，根据`db_name`来划分，再自动写入。
如设置
`
array(
    'db1' => array(
        'tb1',
        'tb2',
        //...
    )
)
`
就可以添加除主数据库外的db1数据库的两个表。