### PR TITLE
默认MD5签名增加分隔符,防止位移篡改参数

### DIFF
--- a/vendor/phalapi/kernal/src/Filter/SimpleMD5Filter.php
+++ b/vendor/phalapi/kernal/src/Filter/SimpleMD5Filter.php
@@ -1,8 +1,8 @@
 <?php
 namespace PhalApi\Filter;
 
-use PhalApi\Filter;
 use PhalApi\Exception\BadRequestException;
+use PhalApi\Filter;
 
 /**
  * SimpleMD5Filter 简单的MD5拦截器
@@ -22,15 +22,20 @@ use PhalApi\Exception\BadRequestException;
  * @author      dogstar <chanzonghuang@gmail.com> 2015-10-23
  */
 
-class SimpleMD5Filter implements Filter {
+class SimpleMD5Filter implements Filter
+{
 
     protected $signName;
+    protected $divider;
 
-    public function __construct($signName = 'sign') {
+    public function __construct($signName = 'sign', $divider = '=')
+    {
         $this->signName = $signName;
+        $this->divider = $divider;
     }
 
-    public function check() {
+    public function check()
+    {
         $allParams = \PhalApi\DI()->request->getAll();
         if (empty($allParams)) {
             return;
@@ -47,12 +52,16 @@ class SimpleMD5Filter implements Filter {
         }
     }
 
-    protected function encryptAppKey($params) {
+    protected function encryptAppKey($params)
+    {
         ksort($params);
 
         $paramsStrExceptSign = '';
-        foreach ($params as $val) {
-            $paramsStrExceptSign .= $val;
+
+        foreach ($params as $index => $val) {
+            if (isset($val) && $val) {
+                $paramsStrExceptSign .= $index . $this->divider . $val;
+            }
         }
 
         return md5($paramsStrExceptSign);


### PR DESCRIPTION
请求1: ?s=Order.insert&total_fee=100&phone=18887655655

请求2: ?s=Order.insert&total_fee=1001888&phone=7655655

签名串:Order.insert10018887655655

请求1和请求2的签名串是一致的,获取到请求参数后,可以通过参数位移来串改参数,但是sign值是对的

很多新人开发者,会直接使用这个签名方法,建议改下, 或者在DI注册服务和文档里,删掉默认SimpleMD5Filter这个默认拦截器

如果合并,文档要改动
签名参数排除了空值,默认分隔符为"="