### PR TITLE
fix:使用window.localStorage存储接口的在线调试参数

### DIFF
--- a/src/view/docs/api_desc_tpl.php
+++ b/src/view/docs/api_desc_tpl.php
@@ -212,7 +212,7 @@ EOT;
         <tr>
             <td>service</td>
             <td><font color="red"><?php echo \PhalApi\T('Required'); ?></font></td>
-            <td><div class="ui fluid input disabled"><input name="service" data-source="get" value="<?php echo $service; ?>" style="width:100%;" class="C_input" /></div></td>
+            <td><div class="ui fluid input disabled"><input name="service" data-source="get" value="<?php echo $service; ?>" style="width:100%;" class="C_input" id="service" /></div></td>
         </tr>
 <?php
 foreach ($rules as $key => $rule){

--- a/src/view/docs/api_footer.php
+++ b/src/view/docs/api_footer.php
@@ -20,7 +20,10 @@
   </div>
 
     <script type="text/javascript">
-	
+        let elem = document.getElementById('service');
+        let sep = '_';
+        let service = elem ? elem.value + sep : sep;
+
         function getData() {
             var data = new FormData();
             var param = [];
@@ -33,7 +36,13 @@
                             data.append(e.name, e.value);
                         }
 
-                        if (e.name != "service") $.cookie(e.name, e.value, {expires: 30});
+                        if (e.name !== "service" && e.value !== '') {
+                            if (window.localStorage) {
+                                localStorage.setItem(service + e.name, e.value);
+                            } else {
+                                $.cookie(service + e.name, e.value, {expires: 30});
+                            }
+                        }
                     } else{
                         var files = e.files;
                         if (files.length == 1){
@@ -99,8 +108,13 @@
         // 填充历史数据
         function fillHistoryData() {
             $("td input").each(function(index,e) {
-                var cookie_value = $.cookie(e.name);
-                if (e.name != "service" && cookie_value != "" && cookie_value !== undefined) {
+                let cookie_value;
+                if (window.localStorage) {
+                    cookie_value = localStorage.getItem(service + e.name);
+                } else {
+                    cookie_value = $.cookie(service + e.name);
+                }
+                if (e.name !== "service" && cookie_value !== "" && cookie_value !== undefined) {
                     e.value = cookie_value;
                 }
             });


### PR DESCRIPTION
使用window.localStorage存储接口的在线调试参数，每个接口参数互不影响；请求接口时不附加cookie。