### PR TITLE
修复.env文件不存在时一直报Warning日志：WARNING|Warning(2)：file_get_contents(D:\laragon\www\phalapi\public\..\.env): failed to open stream: No such file or directory [文件：D:\laragon\www\phalapi\vendor\vlucas\phpdotenv\src\Store\File\Reader.php，行号：73

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -17,12 +17,14 @@ use PhalApi\Error\ApiError;
 
 $di = \PhalApi\DI();
 
-// 加载 .env 环境配置
-$di->dotenv = Dotenv\Dotenv::createImmutable(API_ROOT);
-// .env 非必须的加载
-$di->dotenv->safeLoad(); 
-// .env 必须的加载方式
-// $di->dotenv->load();
+if (file_exists(API_ROOT . '/.env')) {
+    // 加载 .env 环境配置
+    $di->dotenv = Dotenv\Dotenv::createImmutable(API_ROOT);
+    // .env 非必须的加载
+    $di->dotenv->safeLoad();
+    // .env 必须的加载方式
+    // $di->dotenv->load();
+}
 
 // 配置
 $di->config = new FileConfig(API_ROOT . DIRECTORY_SEPARATOR . 'config');


### PR DESCRIPTION
修复.env文件不存在时一直报Warning日志：WARNING|Warning(2)：file_get_contents(D:\laragon\www\phalapi\public\..\.env): failed to open stream: No such file or directory [文件：D:\laragon\www\phalapi\vendor\vlucas\phpdotenv\src\Store\File\Reader.php，行号：73
```
2023-04-10 17:01:38|WARNING|Warning(2)：file_get_contents(D:\laragon\www\phalapi\public\..\.env): failed to open stream: No such file or directory [文件：D:\laragon\www\phalapi\vendor\vlucas\phpdotenv\src\Store\File\Reader.php，行号：73，时间：1681117298]
```
![image](https://user-images.githubusercontent.com/19458454/230878239-0649c89d-aafd-4c16-9470-036f52f2ddad.png)
